### PR TITLE
toc naming amended to correct link to page

### DIFF
--- a/source/en/toc/scheduling.md
+++ b/source/en/toc/scheduling.md
@@ -1,7 +1,7 @@
 - [Introduction](scheduling.html)
 - [Schedule](scheduling_calendar.html)
 - [Events](scheduling_events.html)
-- [Geo Location](geolocation.html)
+- [Geo Location](scheduling_geolocation.html)
 - [Dayparting](scheduling_dayparting.html)
 - [Schedule Now](scheduling_now.html)
 


### PR DESCRIPTION
'schedule' missing from toc